### PR TITLE
request header should send content type and length

### DIFF
--- a/lib/noodle.js
+++ b/lib/noodle.js
@@ -126,6 +126,10 @@ exports.fetch = function (url, query) {
   if (query.post) {
     requestOptions.method = 'POST';
     requestOptions.body   = serialize(query.post);
+    requestOptions.headers = _.extend(requestOptions.headers, {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': requestOptions.body.length
+    });
     query.cache           = false;
   }
 


### PR DESCRIPTION
My post requests don't seem to work. When I add in the content type and length headers to the request this fixes the problem.